### PR TITLE
Return portal_type in ContentTypeClass

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changelog
 1.0.1 - Unreleased
 ------------------
 
-- Nothing changed yet.
+- Change ContentTypeClass to return contenttype-{portal_type} to match
+  what the rest of Plone expects. This fixes sprite based icons for 
+  pages/documents.
+  [gaudenz]
 
 
 1.0 - 2011-07-19

--- a/plone/app/contentlisting/catalog.py
+++ b/plone/app/contentlisting/catalog.py
@@ -114,6 +114,9 @@ class CatalogContentListingObject(BaseContentListingObject):
     def Type(self):
         return self._brain.Type
 
+    def PortalType(self):
+        return self._brain.portal_type
+
     def listCreators(self):
         """ """
         return self._brain.listCreators

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -101,7 +101,7 @@ class BaseContentListingObject(object):
         """A normalised type name that identifies the object in listings.
         used for CSS styling"""
         return "contenttype-" + queryUtility(IIDNormalizer).normalize(
-            self.Type())
+            self.PortalType())
 
     def ReviewStateClass(self):
         """A normalised review state string for CSS styling use in listings."""

--- a/plone/app/contentlisting/realobject.py
+++ b/plone/app/contentlisting/realobject.py
@@ -89,3 +89,7 @@ class RealContentListingObject(BaseContentListingObject):
 # Currently Type() returns different values depending on the data source being
 # a brain or a real object. Probably needed. Support for all the attributes
 # from the indexablemetadata wrappers.
+
+    def PortalType(self):
+        obj = self.getObject()
+        return obj.portal_type

--- a/plone/app/contentlisting/tests/test_integration_unit.py
+++ b/plone/app/contentlisting/tests/test_integration_unit.py
@@ -130,7 +130,7 @@ class TestIndividualCatalogContentItems(ContentlistingFunctionalTestCase):
 
     def test_item_ContentTypeClass(self):
         # checking the that we print nice strings for css class identifiers
-        self.assertEqual(self.item.ContentTypeClass(), 'contenttype-page')
+        self.assertEqual(self.item.ContentTypeClass(), 'contenttype-document')
 
     def test_item_Language(self):
         self.assertEqual(self.item.Language(), 'en')
@@ -211,7 +211,7 @@ class TestIndividualRealContentItems(ContentlistingFunctionalTestCase):
 
     def test_item_ContentTypeClass(self):
         # checking the that we print nice strings for css class identifiers
-        self.assertEqual(self.item.ContentTypeClass(), 'contenttype-page')
+        self.assertEqual(self.item.ContentTypeClass(), 'contenttype-document')
 
     def test_item_Language(self):
         self.assertEqual(self.item.Language(), 'en')


### PR DESCRIPTION
Change ContentTypeClass to return contenttype-{portal_type} to match
what the rest of Plone expects. This fixes sprite based content icons
for documents/pages.

I ran bin/alltests with this change and no tests broke. But as I'm not sure about the reasons why this was made to differ from the rest of plone I'm sending this as a pull request.
