### PR TITLE
Introduce ``@@contentlisting`` with Collection support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 ------------------
 
 - Introduce ``@@contentlisting`` view, which is also supports Collections from
-  plone.app.contenttypes including filtering of results.
+  plone.app.contenttypes including filtering of results. This gives us a
+  unified interface for listing content from Folders or Collections.
   Deprecate ``@@folderListing``, which is kept for BBB compatibility.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
-1.1.2 (unreleased)
+1.2 (unreleased)
 ------------------
+
+- Introduce ``@@contentlisting`` view, which is also supports Collections from
+  plone.app.contenttypes including filtering of results.
+  Deprecate ``@@folderListing``, which is kept for BBB compatibility.
+  [thet]
 
 - Pep8.
   [thet]

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -22,27 +22,38 @@ Making or getting a contentListing
 The typical way to get a contentlisting is to call one of two built-in views:
 
 
-Listing the contents of a folder
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Listing the contents of a Folder or Collection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In Page templates getting the contents of a folder is as simple as this::
+In Page templates getting the contents of a folder or the results of a
+collection is as simple as this::
 
-  context/@@folderListing
+    context/@@contentlisting
 
 Every template-writer's dream ;)
+
+.. note::
+
+    In previous versions there was only support to list the contents of a
+    folder with ``context/@@folderListing``. There was no collection support.
+    The ``@@folderListing`` view is kept for compatibility, but we encourage
+    you to use the ``@@contentlisting`` instead.
+    
+
 
 A real example of listing the titles of the content objects of a folder::
 
   <ul>
-    <li tal:repeat="item context/@@folderListing" tal:content="item/Title"/>
+    <li tal:repeat="item context/@@contentlisting" tal:content="item/Title"/>
   </ul>
 
-The context in which it is called defines which folder is listed.
+The context in which it is called defines which folder is listed or which
+collection results are queried.
 
 You can also use Python expressions to be able to pass parameters, like which
 content type or review state you want to use::
 
-  <li tal:repeat="item python:context.restrictedTraverse('@@folderListing')(portal_type='Document')">
+  <li tal:repeat="item python:context.restrictedTraverse('@@contentlisting')(portal_type='Document')">
 
 Batching can be done like this::
 
@@ -50,7 +61,7 @@ Batching can be done like this::
       Batch python:modules['Products.CMFPlone'].Batch;
       b_size python:int(request.get('b_size', 20));
       b_start python:int(request.get('b_start', 0));
-      results python:context.restrictedTraverse('@@folderListing')(batch=True, b_size=b_size, b_start=b_start);
+      results python:context.restrictedTraverse('@@contentlisting')(batch=True, b_size=b_size, b_start=b_start);
       batch python:Batch(results, b_size, b_start);">
     <li tal:repeat="item results"
         tal:content="item/Title" />
@@ -58,15 +69,19 @@ Batching can be done like this::
   </ul>
 
 Note that you iterate directly over the results that you get from
-``@@folderListing``.  The definition of ``batch`` is only used in the
+``@@contentlisting``.  The definition of ``batch`` is only used in the
 ``batch_macros`` call.
 
 In Python a ContentListing of a particular folder's contents can be fetched
 by using::
 
-    >>> path.to.your.folder.restrictedTraverse('@@folderListing')()
+    >>> path.to.your.folder.restrictedTraverse('@@contentlisting')()
 
-The folderListing view called above implements all the logic the old
+Exactly the same for collections::
+
+    >>> path.to.your.collection.restrictedTraverse('@@contentlisting')()
+
+The contentlisting view called above implements all the logic the old
 getFolderContents script in Plone used to do. The old script has been left in
 place to not break compatibility for customizations and add-ons that might
 depend on its particular return values.

--- a/plone/app/contentlisting/browser.py
+++ b/plone/app/contentlisting/browser.py
@@ -26,3 +26,22 @@ class FolderListing(BrowserView):
         catalog = getToolByName(self.context, 'portal_catalog')
         results = catalog(query)
         return IContentListing(results)
+
+
+class ContentListingCollection(BrowserView):
+
+    def __call__(self, batch=False, b_size=20, b_start=0, **kw):
+
+        if 'orphan' in kw:
+            # At the moment, orphan keyword is not supported by
+            # plone.app.contenttypes Collection behavior, nor by
+            # plone.app.querystring's querybuilder.
+            del kw['orphan']
+
+        res = self.context.results(
+            batch=batch,
+            b_size=b_size,
+            b_start=b_start,
+            custom_query=kw
+        )
+        return res

--- a/plone/app/contentlisting/configure.zcml
+++ b/plone/app/contentlisting/configure.zcml
@@ -1,5 +1,6 @@
 <configure xmlns="http://namespaces.zope.org/zope"
-           xmlns:browser="http://namespaces.zope.org/browser">
+           xmlns:browser="http://namespaces.zope.org/browser"
+           xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <adapter
       factory=".contentlisting.ContentListing"
@@ -41,6 +42,22 @@
       for="Products.CMFCore.interfaces.IContentish "
       />
 
+  <browser:page
+      name="contentlisting"
+      class=".browser.FolderListing"
+      permission="zope2.View"
+      for="Products.CMFCore.interfaces.IFolderish"
+      />
+
+  <browser:page
+      name="contentlisting"
+      class=".browser.ContentListingCollection"
+      permission="zope2.View"
+      for="plone.app.contenttypes.behaviors.collection.ISyndicatableCollection"
+      zcml:condition="installed plone.app.contenttypes"
+      />
+
+  <!-- BBB -->
   <browser:page
       name="folderListing"
       class=".browser.FolderListing"

--- a/plone/app/contentlisting/tests/integration.rst
+++ b/plone/app/contentlisting/tests/integration.rst
@@ -2,7 +2,7 @@ Basic usage
 ===========
 
 The idea behind plone.app.contentlisting is to have a unified way of listing
-Plone content whenever needed, whether in folderlistings, collections,
+Plone content whenever needed, whether in contentlistings, collections,
 portlets or search results.
 
 It should be simple to use for new developers and integrators. The core concept
@@ -64,36 +64,36 @@ This item's origin is no longer a Brain, but the real object
 For user and integrator convenience we also include a couple of handy
 browser views to get to these listings.
 
-    >>> folderlisting = self.portal.restrictedTraverse('@@folderListing')()
-    >>> print(folderlisting)
+    >>> contentlisting = self.portal.restrictedTraverse('@@contentlisting')()
+    >>> print(contentlisting)
     <plone.app.contentlisting.contentlisting.ContentListing object ...
 
-    >>> len(folderlisting)
+    >>> len(contentlisting)
     3
 
-We can even slice the new folderlisting
+We can even slice the new contentlisting
 
-    >>> len (folderlisting[2:4])
+    >>> len (contentlisting[2:4])
     1
 
-    >>> len(self.portal.restrictedTraverse('news/@@folderListing')())
+    >>> len(self.portal.restrictedTraverse('news/@@contentlisting')())
     1
 
 And we can use batching in it:
 
-    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@folderListing')()]
+    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@contentlisting')()]
     ['http://nohost/plone/test-folder', 'http://nohost/plone/front-page', 'http://nohost/plone/news']
-    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@folderListing')(batch=True, b_size=1)]
+    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@contentlisting')(batch=True, b_size=1)]
     ['http://nohost/plone/test-folder']
-    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@folderListing')(batch=True, b_start=1, b_size=1)]
+    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@contentlisting')(batch=True, b_start=1, b_size=1)]
     ['http://nohost/plone/front-page']
-    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@folderListing')(batch=True, b_start=2, b_size=1)]
+    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@contentlisting')(batch=True, b_start=2, b_size=1)]
     ['http://nohost/plone/news']
-    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@folderListing')(batch=True, b_start=1, b_size=2)]
+    >>> [i.getURL() for i in self.portal.restrictedTraverse('@@contentlisting')(batch=True, b_start=1, b_size=2)]
     ['http://nohost/plone/front-page', 'http://nohost/plone/news']
 
 We can use filtering by catalog indexes:
-    >>> len(self.portal.restrictedTraverse('@@folderListing')(portal_type='Document'))
+    >>> len(self.portal.restrictedTraverse('@@contentlisting')(portal_type='Document'))
     1
 
 
@@ -102,10 +102,10 @@ Append View Action
 
 Some types may require '/view' appended to their URLs. Currently these don't
 
-    >>> frontpage = self.portal.restrictedTraverse('@@folderListing')(id='front-page')[0]
+    >>> frontpage = self.portal.restrictedTraverse('@@contentlisting')(id='front-page')[0]
     >>> frontpage.appendViewAction()
     ''
-    >>> news = self.portal.restrictedTraverse('@@folderListing')(id='news')[0]
+    >>> news = self.portal.restrictedTraverse('@@contentlisting')(id='news')[0]
     >>> news.appendViewAction()
     ''
     >>> realfrontpage = IContentListingObject(self.portal['front-page'])
@@ -139,11 +139,11 @@ Visibility in Navigation
 
 Items by default are visible in navigation
 
-    >>> frontpage = self.portal.restrictedTraverse('@@folderListing')(id='front-page')[0]
+    >>> frontpage = self.portal.restrictedTraverse('@@contentlisting')(id='front-page')[0]
     >>> frontpage.isVisibleInNav()
     True
 
-    >>> news = self.portal.restrictedTraverse('@@folderListing')(id='news')[0]
+    >>> news = self.portal.restrictedTraverse('@@contentlisting')(id='news')[0]
     >>> news.isVisibleInNav()
     True
 
@@ -181,7 +181,7 @@ way is the exclude_from_nav property being true
 
 This will be indexed, so an object isn't necessary to check this
 
-    >>> frontpage = self.portal.restrictedTraverse('@@folderListing')(id='front-page')[0]
+    >>> frontpage = self.portal.restrictedTraverse('@@contentlisting')(id='front-page')[0]
     >>> frontpage.isVisibleInNav()
     False
     >>> print(frontpage.getDataOrigin())
@@ -200,7 +200,7 @@ We can also turn it off again.
     >>> frontpage_object.exclude_from_nav = False
     >>> frontpage_object.reindexObject()
 
-    >>> frontpage = self.portal.restrictedTraverse('@@folderListing')(id='front-page')[0]
+    >>> frontpage = self.portal.restrictedTraverse('@@contentlisting')(id='front-page')[0]
     >>> frontpage.isVisibleInNav()
     True
 


### PR DESCRIPTION
Introduce ``@@contentlisting`` view, which is also supports Collections from
plone.app.contenttypes including filtering of results. This gives us a
  unified interface for listing content from Folders or Collections.

Ultimately, it would be nice to have Folders and Collections both implement a common interface like ``IContentlistable``, so that we can drop the need to make two zcml browser view registrations if we want to support both types. But that's out of scope for this pull request.

Deprecate ``@@folderListing``, which is kept for BBB compatibility.

The change from ``folderListing`` to ``contentlisting`` is a bit harsh, but the term folderListing does not work for Collections, while contentlisting does work for both. Also, I dislike the uppercase "L" in ``folderListing``, let's get rid of it. Of course, the old ``folderListing`` view is still registered to not break any other packages depending on it.