### PR TITLE
Make isVisibleInNav method read navigation displayed types settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make isVisibleInNav method read navigation displayed types settings from
+  plone.app.registry instead of portal properties. This fixes
+  https://github.com/plone/Products.CMFPlone/issues/454.
+  [timo]
 
 
 1.1.2 (2015-05-05)

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -1,9 +1,12 @@
 from .interfaces import IContentListing
 from .interfaces import IContentListingObject
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import INavigationSchema
 from plone.i18n.normalizer.interfaces import IIDNormalizer
+from plone.registry.interfaces import IRegistry
 from zope import interface
 from zope.component import queryUtility
+from zope.component import getUtility
 
 
 class ContentListing(object):
@@ -134,10 +137,7 @@ class BaseContentListingObject(object):
         ):
             return False
 
-        from plone.registry.interfaces import IRegistry
-        from zope.component import getUtility
         registry = getUtility(IRegistry)
-        from Products.CMFPlone.interfaces import INavigationSchema
         navigation_settings = registry.forInterface(
             INavigationSchema,
             prefix='plone'

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -133,10 +133,24 @@ class BaseContentListingObject(object):
                 else self.exclude_from_nav
         ):
             return False
-        portal_properties = getToolByName(self.getDataOrigin(), 'portal_properties')  # noqa
-        navtree_properties = getattr(portal_properties, 'navtree_properties')
-        if self.portal_type in list(navtree_properties.metaTypesNotToList):
+
+        from plone.registry.interfaces import IRegistry
+        from zope.component import getUtility
+        registry = getUtility(IRegistry)
+        from Products.CMFPlone.interfaces import INavigationSchema
+        navigation_settings = registry.forInterface(
+            INavigationSchema,
+            prefix='plone'
+        )
+        if self.portal_type not in navigation_settings.displayed_types:
             return False
+
+        portal_properties = getToolByName(
+            self.getDataOrigin(),
+            'portal_properties'
+        )
+        navtree_properties = getattr(portal_properties, 'navtree_properties')
+
         if self.id in list(navtree_properties.idsNotToList):
             return False
         return True

--- a/plone/app/contentlisting/tests/integration.rst
+++ b/plone/app/contentlisting/tests/integration.rst
@@ -208,26 +208,35 @@ We can also turn it off again.
     >>> realfrontpage.isVisibleInNav()
     True
 
-We can also exclude anything of a particular type using metaTypesNotToList
+We can also exclude anything of a particular type using the displayed type setting::
 
-    >>> navtree_properties = getattr(getToolByName(self.portal, 'portal_properties'), 'navtree_properties')
-    >>> navtree_properties.metaTypesNotToList = [frontpage.portal_type]
+    >>> from plone.registry.interfaces import IRegistry
+    >>> from zope.component import getUtility
+    >>> registry = getUtility(IRegistry)
+    >>> from Products.CMFPlone.interfaces import INavigationSchema
+    >>> navigation_settings = registry.forInterface(
+    ...     INavigationSchema,
+    ...     prefix='plone'
+    ... )
+    >>> navigation_settings.displayed_types = (frontpage.portal_type, news.portal_type)
+    >>> frontpage.isVisibleInNav()
+    True
+    >>> realfrontpage.isVisibleInNav()
+    True
+    >>> news.isVisibleInNav()
+    True
+    >>> navigation_settings.displayed_types = ()
     >>> frontpage.isVisibleInNav()
     False
     >>> realfrontpage.isVisibleInNav()
     False
     >>> news.isVisibleInNav()
-    True
-    >>> navtree_properties.metaTypesNotToList = []
-    >>> frontpage.isVisibleInNav()
-    True
-    >>> realfrontpage.isVisibleInNav()
-    True
-    >>> news.isVisibleInNav()
-    True
+    False
 
 Finally, particular ids can be excluded from listings
 
+    >>> navigation_settings.displayed_types = (frontpage.portal_type, news.portal_type)
+    >>> navtree_properties = getattr(getToolByName(self.portal, 'portal_properties'), 'navtree_properties')
     >>> navtree_properties.idsNotToList = [news.id]
     >>> frontpage.isVisibleInNav()
     True


### PR DESCRIPTION
from plone.app.registry instead of portal properties.