### PR TITLE
It seems that in zope4 brains can not longer acquire the REQUEST.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- In Zope4 brains can not longer acquire the REQUEST.
+  [pbauer]
 
 
 1.3.1 (2017-08-08)

--- a/plone/app/contentlisting/catalog.py
+++ b/plone/app/contentlisting/catalog.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
-from Acquisition import aq_get
 from plone.app.contentlisting.contentlisting import BaseContentListingObject
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.registry.interfaces import IRegistry
@@ -8,6 +7,7 @@ from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 from zope.component import queryUtility
+from zope.globalrequest import getRequest
 from zope.interface import implementer
 
 
@@ -25,7 +25,7 @@ class CatalogContentListingObject(BaseContentListingObject):
     def __init__(self, brain):
         self._brain = brain
         self._cached_realobject = None
-        self.request = aq_get(brain, 'REQUEST')
+        self.request = getRequest()
 
     def __repr__(self):
         return '<plone.app.contentlisting.catalog.'\


### PR DESCRIPTION
Seems weird but there many test failures like this:

```
Error in test test_blacklisted_types_in_results (Products.CMFPlone.tests.testSearch.TestSection)
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/workspace/plip-zope4@2/src/Products.CMFPlone/Products/CMFPlone/tests/testSearch.py", line 149, in test_blacklisted_types_in_results
    self.assertTrue('my-page1' in [r.getId() for r in res],
  File "/home/jenkins/.buildout/eggs/plone.app.contentlisting-1.3.1-py2.7.egg/plone/app/contentlisting/contentlisting.py", line 47, in __iter__
    yield IContentListingObject(obj)
  File "/home/jenkins/.buildout/eggs/zope.component-4.4.0-py2.7.egg/zope/component/hookable.py", line 33, in __call__
    return self.__implementation(*args, **kw)
  File "/home/jenkins/.buildout/eggs/zope.component-4.4.0-py2.7.egg/zope/component/hooks.py", line 119, in adapter_hook
    return siteinfo.adapter_hook(interface, object, name, default)
  File "/home/jenkins/.buildout/eggs/plone.app.contentlisting-1.3.1-py2.7.egg/plone/app/contentlisting/catalog.py", line 28, in __init__
    self.request = aq_get(brain, 'REQUEST')
AttributeError: REQUEST
```
 See http://jenkins.plone.org/view/PLIPs/job/plip-zope4/46