### PR TITLE
Removed unittest2 from tests. [1.3.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,13 +14,15 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Removed ``unittest2`` from tests.
+  We were not declaring this as dependency, and were not using any of its features.
+  [maurits]
 
 
 1.3.2 (2017-11-26)
 ------------------
 
-Bug fixes: 
+Bug fixes:
 
 - Fix tests after collective.indexing moved into core.
   [pbauer]

--- a/plone/app/contentlisting/tests/test_integration_unit.py
+++ b/plone/app/contentlisting/tests/test_integration_unit.py
@@ -411,7 +411,6 @@ class TestCollectionResults(unittest.TestCase):
 
 
 def test_suite():
-    import unittest2 as unittest
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestSetup))
     suite.addTest(unittest.makeSuite(TestIndividualCatalogContentItems))


### PR DESCRIPTION
We were not declaring this as dependency, and were not using any of its features.

I was getting this error on Jenkins 5.1 on an unrelated pull request:

```
Test-module import failures:

Module: plone.app.contentlisting.tests.test_integration_unit

ImportError: No module named unittest2
```

See http://jenkins.plone.org/job/pull-request-5.1/701/