### PR TITLE
Improve navroot url detection for mimetype icon

### DIFF
--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from Acquisition import aq_base
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces import INavigationSchema
-from Products.MimetypesRegistry.MimeTypeItem import guess_icon_path
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.app.layout.navigation.root import getNavigationRoot
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import INavigationSchema
+from Products.MimetypesRegistry.MimeTypeItem import guess_icon_path
 from zope.component import getUtility
 from zope.component import queryUtility
 from zope.interface import implementer

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from Acquisition import aq_base
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import INavigationSchema
+from Products.MimetypesRegistry.MimeTypeItem import guess_icon_path
+from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.app.layout.navigation.root import getNavigationRoot
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces import INavigationSchema
-from Products.MimetypesRegistry.MimeTypeItem import guess_icon_path
 from zope.component import getUtility
 from zope.component import queryUtility
 from zope.interface import implementer
@@ -164,7 +165,8 @@ class BaseContentListingObject(object):
 
     def MimeTypeIcon(self):
         mimeicon = None
-        navroot = getNavigationRoot(self._brain)
+        navroot = api.portal.get_navigation_root(self._brain.getObject())
+        navroot_url = navroot.absolute_url()
         contenttype = aq_base(
             getattr(self._brain, 'mime_type', None),
         )
@@ -175,7 +177,7 @@ class BaseContentListingObject(object):
             )
             ctype = mtt.lookup(contenttype)
             mimeicon = os.path.join(
-                navroot,
+                navroot_url,
                 guess_icon_path(ctype[0]),
             )
 


### PR DESCRIPTION
Previous mode had a problem with vhm configurations.

getNavigationRoot return root's physical path and not the right root physical path.
For example if we have a website published with some vhm configuration, the physical path is not enough because the path is wrong.

A possible solution could be using _getNavigationRootObject_ instead _getNavigationRoot_ and get its absolute_url.

I used plone.api to compliance with the standard.

I have also a question about compatibility: is ok to use the master with plone 5.1? Or it has some fixes only for Python3?