### PR TITLE
Use human_readable_size from Products.CMFPlone.utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 
 - Python 3 support
   [hvelarde, gforcada, davisagli]
+- Use human_readable_size from Products.CMFPlone.utils to replace getObjSize
+  script. #1801
+  [reinhardt]
 
 Bug fixes:
 

--- a/plone/app/contentlisting/realobject.py
+++ b/plone/app/contentlisting/realobject.py
@@ -6,6 +6,7 @@ from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import human_readable_size
 from zope.interface import implementer
 
 
@@ -73,13 +74,12 @@ class RealContentListingObject(BaseContentListingObject):
         except TypeError:
             # no primary field available, dexterity raises a TypeError
             # with the slightly missleading message 'could not adapt'.
-            return 0
+            primary_field_info = None
         if primary_field_info is None or not primary_field_info.value:
-            return 0
-        return obj.getObjSize(
-            None,
-            getattr(primary_field_info.value, 'size', 0),
-        )
+            size = 0
+        else:
+            size = getattr(primary_field_info.value, 'size', 0)
+        return human_readable_size(size)
 
     def review_state(self):
         obj = self.getObject()

--- a/plone/app/contentlisting/tests/test_integration_unit.py
+++ b/plone/app/contentlisting/tests/test_integration_unit.py
@@ -231,6 +231,9 @@ class TestIndividualRealContentItems(unittest.TestCase):
         )
         self.assertEqual(self.item.getURL(), self.realitem.absolute_url())
 
+    def test_item_getSize(self):
+        self.assertEqual(self.item.getSize().upper(), '0 KB')
+
     def test_item_reviewState(self):
         wftool = getToolByName(self.realitem, 'portal_workflow')
         wf = wftool.getInfoFor(self.realitem, 'review_state')


### PR DESCRIPTION
Replaces getObjSize script.
Also refactored getSize a little so that it consistently returns a string.
*Attention:* Depends on plone/Products.CMFPlone#2544.
See also https://github.com/plone/Products.CMFPlone/issues/1801