### PR TITLE
Do not throw an error if the contenttype is not in the mimetyes_registry

### DIFF
--- a/news/41.bugfix
+++ b/news/41.bugfix
@@ -1,0 +1,2 @@
+Do not throw an error when the contenttype is not in the mimetypes_registry.
+[tschorr]

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -174,9 +174,10 @@ class BaseContentListingObject(object):
                 'mimetypes_registry',
             )
             ctype = mtt.lookup(contenttype)
-            mimeicon = os.path.join(
-                navroot,
-                guess_icon_path(ctype[0]),
-            )
+            if ctype:
+                mimeicon = os.path.join(
+                    navroot,
+                    guess_icon_path(ctype[0]),
+                )
 
         return mimeicon


### PR DESCRIPTION
Same problem as https://github.com/plone/plone.app.portlets/pull/129