### PR TITLE
build the mime-type icon with absolute url

### DIFF
--- a/news/44.bugfix
+++ b/news/44.bugfix
@@ -1,0 +1,2 @@
+Build the mime-type icon url with an absolute url. Fixes #44
+[erral]

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -3,7 +3,7 @@
 from Acquisition import aq_base
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contentlisting.interfaces import IContentListingObject
-from plone.app.layout.navigation.root import getNavigationRoot
+from plone.app.layout.navigation.root import getNavigationRootObject
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
@@ -164,7 +164,9 @@ class BaseContentListingObject(object):
 
     def MimeTypeIcon(self):
         mimeicon = None
-        navroot = getNavigationRoot(self._brain)
+        portal_url_object = getToolByName(self._brain, 'portal_url')
+        portal = portal_url_object.getPortalObject()
+        navroot = getNavigationRootObject(self._brain, portal)
         contenttype = aq_base(
             getattr(self._brain, 'mime_type', None),
         )
@@ -176,7 +178,7 @@ class BaseContentListingObject(object):
             ctype = mtt.lookup(contenttype)
             if ctype:
                 mimeicon = os.path.join(
-                    navroot,
+                    navroot.absolute_url(),
                     guess_icon_path(ctype[0]),
                 )
 


### PR DESCRIPTION
Fixes #44  for 2.x branch (Plone 5.2)

