### PR TITLE
build mime-type icon url with absolute url

### DIFF
--- a/news/44.bugfix
+++ b/news/44.bugfix
@@ -1,0 +1,2 @@
+Build mime-type icon url with the absolute url. Fixes #44
+[erral]

--- a/plone/app/contentlisting/contentlisting.py
+++ b/plone/app/contentlisting/contentlisting.py
@@ -1,7 +1,7 @@
 from Acquisition import aq_base
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contentlisting.interfaces import IContentListingObject
-from plone.app.layout.navigation.root import getNavigationRoot
+from plone.app.layout.navigation.root import getNavigationRootObject
 from plone.base.interfaces import INavigationSchema
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.registry.interfaces import IRegistry
@@ -162,7 +162,9 @@ class BaseContentListingObject:
 
     def MimeTypeIcon(self):
         mimeicon = None
-        navroot = getNavigationRoot(self._brain)
+        portal_url_object = getToolByName(self._brain, 'portal_url')
+        portal = portal_url_object.getPortalObject()
+        navroot = getNavigationRootObject(self._brain, portal)
         contenttype = aq_base(
             getattr(self._brain, "mime_type", None),
         )
@@ -174,7 +176,7 @@ class BaseContentListingObject:
             ctype = mtt.lookup(contenttype)
             if ctype:
                 mimeicon = os.path.join(
-                    navroot,
+                    navroot.absolute_url(),
                     guess_icon_path(ctype[0]),
                 )
 


### PR DESCRIPTION
Fixes #44 for master.

We have no screenshot here because in Plone 6 the icons are not rendered using the content listing `MimeTypeIcon` method.

But if we show it in a custom template it would be as follows:

Before:

See that we are browsing the site in a domain, and in such a case, the portal path (/Plone) should not be visible but it is:

![Pantaila-argazkia 2022-08-06 21-07-01](https://user-images.githubusercontent.com/817365/183262861-9e8b5482-93fd-4745-ae67-e18ce0ec43e2.png)

After:

![Pantaila-argazkia 2022-08-06 21-08-54](https://user-images.githubusercontent.com/817365/183262924-e793f38b-c366-443d-a9c0-dba85bdf8d11.png)

