### PR TITLE
Backport PR 48 : __getattr__ of realobject should keep the object wrapped in acquisition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- In RealContentListingObject.__getattr__ check attribute existence without acquisition but return the attribute with acquisition
+  in case it is a method that needs acquisition.
+  [gbastien, sdelcourt] (#47)
 
 
 1.3.4 (2019-12-11)

--- a/plone/app/contentlisting/realobject.py
+++ b/plone/app/contentlisting/realobject.py
@@ -34,11 +34,11 @@ class RealContentListingObject(BaseContentListingObject):
         if name.startswith('_'):
             raise AttributeError(name)
         obj = self.getObject()
-        obj_name = getattr(aq_base(obj), name, None)
-        if obj_name is not None:
-            return obj_name
-        else:
-            raise AttributeError(name)
+        if hasattr(aq_base(obj), name):
+            obj_name = getattr(obj, name, None)
+            if obj_name is not None:
+                return obj_name
+        raise AttributeError(name)
 
     def getObject(self):
         return self._realobject

--- a/plone/app/contentlisting/tests/test_integration_unit.py
+++ b/plone/app/contentlisting/tests/test_integration_unit.py
@@ -205,14 +205,16 @@ class TestIndividualRealContentItems(unittest.TestCase):
         # AttributeError
         self.assertRaises(AttributeError, self.item.__getattr__, 'foo')
 
-    def test_special_getattr_from_object(self):
-        # Asking for an attribute not in the contentlistingobject, should
-        # defer lookup to the brain
-        self.assertEqual(self.item.absolute_url(), '')
+    def test_item_getattr_acquisition(self):
+        # absolute_url needs acquisition to work
+        # on the object
         self.assertEqual(
-            repr(self.item.getDataOrigin()),
-            '<Document at /plone/test-folder/mypage>',
-        )
+            self.item._realobject.absolute_url(),
+            "http://nohost/plone/test-folder/mypage")
+        # on the contentlisting object
+        self.assertEqual(
+            self.item.absolute_url(),
+            "http://nohost/plone/test-folder/mypage")
 
     def test_item_Title(self):
         self.assertEqual(self.item.Title(), 'My Page')


### PR DESCRIPTION
Hello, 

I want to backport the fix of [#47](https://github.com/plone/plone.app.contentlisting/pull/47 ) [#48](https://github.com/plone/plone.app.contentlisting/pull/47) to the 1.3.x branch.

The __getattr__ of realobject should check if the attribute really belongs the unwrapped object (and not a parent) but the "get" computation should be on the wrapped object.

Thank you for the review and feedback.

Simon