### PR TITLE
Break cyclic dependency

### DIFF
--- a/news/3764.internal
+++ b/news/3764.internal
@@ -1,0 +1,3 @@
+Drop p.a.contenttypes install dependency, it is actually a soft one only.
+This allows to break a cyclic dependency.
+[gforcada]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "plone.base",
         "Products.MimetypesRegistry",
         "Products.ZCatalog",
-        "plone.app.contenttypes",
         "plone.i18n",
         "plone.registry",
         "plone.rfc822",


### PR DESCRIPTION
Part of https://github.com/plone/Products.CMFPlone/issues/3764

`plone.app.event` depends on `plone.app.contentlisting` which in turn depends on `plone.app.contenttypes` which loops back to depending on `plone.app.event` 😵‍💫 

By dropping the `plone.app.contenttypes` dependency here in `plone.app.contentlisting` we break the cycle 🎉 🧹 