### PR TITLE
Add image_scales support for RealContentListingObject

### DIFF
--- a/news/64.bugfix
+++ b/news/64.bugfix
@@ -1,0 +1,1 @@
+Support image_scales in RealContentListingObject. @davisagli

--- a/plone/app/contentlisting/realobject.py
+++ b/plone/app/contentlisting/realobject.py
@@ -1,11 +1,13 @@
 from Acquisition import aq_get
 from plone.app.contentlisting.contentlisting import BaseContentListingObject
 from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.base.interfaces import IImageScalesAdapter
 from plone.base.utils import base_hasattr
 from plone.base.utils import human_readable_size
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
+from zope.component import getMultiAdapter
 from zope.interface import implementer
 
 
@@ -105,3 +107,7 @@ class RealContentListingObject(BaseContentListingObject):
     def PortalType(self):
         obj = self.getObject()
         return obj.portal_type
+
+    def image_scales(self):
+        obj = self.getObject()
+        return getMultiAdapter((obj, self.request), IImageScalesAdapter)()

--- a/plone/app/contentlisting/tests/test_integration_unit.py
+++ b/plone/app/contentlisting/tests/test_integration_unit.py
@@ -4,11 +4,16 @@ from plone.app.contentlisting.tests.base import CONTENTLISTING_FUNCTIONAL_TESTIN
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.batching.interfaces import IBatch
+from plone.namedfile.file import NamedBlobImage
 from Products.CMFCore.utils import getToolByName
 from zope.interface.verify import verifyObject
 
+import base64
 import unittest
 
+TEST_IMAGE_DATA = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
 
 class TestSetup(unittest.TestCase):
     layer = CONTENTLISTING_FUNCTIONAL_TESTING
@@ -264,6 +269,21 @@ class TestIndividualRealContentItems(unittest.TestCase):
                 "Accessing attributes which return ``None`` should not "
                 "result in an AttributeError."
             )
+
+    def test_item_image_scales(self):
+        self.folder.invokeFactory(
+            "Image",
+            "myimage",
+            title="My Image",
+        )
+        myimage = self.folder.myimage
+        myimage.image = NamedBlobImage(
+            data=TEST_IMAGE_DATA,
+            filename="test.png",
+        )
+        item = IContentListingObject(myimage)
+        image_scales = item.image_scales()
+        self.assertIn("download", image_scales["image"][0])
 
 
 class TestFolderContents(unittest.TestCase):

--- a/plone/app/contentlisting/tests/test_integration_unit.py
+++ b/plone/app/contentlisting/tests/test_integration_unit.py
@@ -11,9 +11,11 @@ from zope.interface.verify import verifyObject
 import base64
 import unittest
 
+
 TEST_IMAGE_DATA = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
 )
+
 
 class TestSetup(unittest.TestCase):
     layer = CONTENTLISTING_FUNCTIONAL_TESTING

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
             "plone.app.contenttypes[test]",
             "plone.app.testing",
             "plone.batching",
+            "plone.namedfile",
             "plone.testing",
         ],
     },


### PR DESCRIPTION
Fixes https://github.com/plone/plone.volto/issues/141

Sometimes an IContentListingObject adapter is looked up for a full content object instead of a catalog brain. This gets the RealContentListingObject adapter. For example, this happens in plone.restapi when serializing a relation field value.

RealContentListingObject was missing support for the image_scales field. This adds it, by calling the same adapter that is used to get the value for the catalog indexer.